### PR TITLE
Add MailHog Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ But you can also easily enable ElasticSearch, Postgres, MSSQL, Redis, and more, 
 - MeiliSearch
 - Redis
 - Memcached
+- MailHog
 
 ## Requirements
 

--- a/app/Services/MailHog.php
+++ b/app/Services/MailHog.php
@@ -2,7 +2,7 @@
 
 namespace App\Services;
 
-class Mailhog extends BaseService
+class MailHog extends BaseService
 {
     protected $organization = 'mailhog';
     protected $imageName = 'mailhog';

--- a/app/Services/MailHog.php
+++ b/app/Services/MailHog.php
@@ -12,16 +12,10 @@ class MailHog extends BaseService
                 'shortname' => 'web_port',
                 'prompt'    => 'What will the web port?',
                 'default'   => '8025',
-            ],
-            [
-                'shortname' => 'volume',
-                'prompt'    => 'What is the Docker volume name?',
-                'default'   => 'mailhog_data',
-            ],
+            ]
         ];
 
     protected $dockerRunTemplate = '-p "$port":1025 \
         -p "$web_port":8025 \
-        -v "$volume":/var/lib/mysql \
         "$organization"/"$image_name":"$tag"';
 }

--- a/app/Services/MailHog.php
+++ b/app/Services/MailHog.php
@@ -22,7 +22,6 @@ class MailHog extends BaseService
 
     protected $dockerRunTemplate = '-p "$port":1025 \
         -p "$web_port":8025 \
-        -e MYSQL_ROOT_PASSWORD="$root_password" \
         -v "$volume":/var/lib/mysql \
         "$organization"/"$image_name":"$tag"';
 }

--- a/app/Services/Mailhog.php
+++ b/app/Services/Mailhog.php
@@ -8,19 +8,19 @@ class Mailhog extends BaseService
     protected $imageName = 'mailhog';
     protected $defaultPort = 1025;
     protected $prompts = [
-        [
-            'shortname' => 'volume',
-            'prompt' => 'What is the Docker volume name?',
-            'default' => 'mailhog_data',
-        ],
-        [
-            'shortname' => 'web_port',
-            'prompt' => 'What will the web port?',
-            'default' => '8025',
-        ],
-    ];
+            [
+                'shortname' => 'web_port',
+                'prompt'    => 'What will the web port?',
+                'default'   => '8025',
+            ],
+            [
+                'shortname' => 'volume',
+                'prompt'    => 'What is the Docker volume name?',
+                'default'   => 'mailhog_data',
+            ],
+        ];
 
-    protected $dockerRunTemplate = '-p "$port":3306 \
+    protected $dockerRunTemplate = '-p "$port":1025 \
         -p "$web_port":8025 \
         -e MYSQL_ROOT_PASSWORD="$root_password" \
         -v "$volume":/var/lib/mysql \

--- a/app/Services/Mailhog.php
+++ b/app/Services/Mailhog.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Services;
+
+class Mailhog extends BaseService
+{
+    protected $organization = 'mailhog';
+    protected $imageName = 'mailhog';
+    protected $defaultPort = 1025;
+    protected $prompts = [
+        [
+            'shortname' => 'volume',
+            'prompt' => 'What is the Docker volume name?',
+            'default' => 'mailhog_data',
+        ],
+        [
+            'shortname' => 'web_port',
+            'prompt' => 'What will the web port?',
+            'default' => '8025',
+        ],
+    ];
+
+    protected $dockerRunTemplate = '-p "$port":3306 \
+        -p "$web_port":8025 \
+        -e MYSQL_ROOT_PASSWORD="$root_password" \
+        -v "$volume":/var/lib/mysql \
+        "$organization"/"$image_name":"$tag"';
+}


### PR DESCRIPTION
It installs [MailHog](https://github.com/mailhog/MailHog)

Using [Valet Proxy](https://laravel.com/docs/master/valet#proxying-services) you can add a custom domain to MailHog.

```
valet proxy mailhog http://127.0.0.1:8025
```

Now you can use http://mailhog.test