### PR TITLE
feat: add MariaDB service

### DIFF
--- a/app/Services/MariaDB.php
+++ b/app/Services/MariaDB.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Services;
+
+class MariaDB extends BaseService
+{
+    protected $imageName = 'mariadb';
+    protected $defaultPort = 3306;
+    protected $prompts = [
+        [
+            'shortname' => 'volume',
+            'prompt' => 'What is the Docker volume name?',
+            'default' => 'mariadb_data',
+        ],
+        [
+            'shortname' => 'root_password',
+            'prompt' => 'What will the root password be?',
+            'default' => 'password',
+        ],
+    ];
+
+    protected $dockerRunTemplate = '-p "$port":3306 \
+        -e MYSQL_ROOT_PASSWORD="$root_password" \
+        -v "$volume":/var/lib/mysql \
+        "$organization"/"$image_name":"$tag"';
+}


### PR DESCRIPTION
This adds MariaDB as an alternative to MySQL.

- Website: https://mariadb.org
- Docker image: https://hub.docker.com/_/mariadb

~~I guess it may be worth thinking about https://github.com/tightenco/takeout/issues/53 before merging though, as I think this affects MariaDB as well.~~ 🤔 Looks like MariaDB advise against it though: https://mariadb.com/kb/en/authentication-plugin-mysql_native_password

Actually, it looks like this isn't necessary in PHP `~7.1.16 || >=7.2.4` as it was updated to support it and Takeout requires `^7.2.5`. 👍🏻