### PR TITLE
Command UI improvement proposal

### DIFF
--- a/app/Commands/DisableCommand.php
+++ b/app/Commands/DisableCommand.php
@@ -90,8 +90,8 @@ class DisableCommand extends Command
                 $option = $this->menu('No containers are running. Turn off Docker for Mac?', [
                     'Yes',
                     'No',
-                ])->open();
                 
+                ])->disableDefaultItems()->open();
                 if ($option === 0) {
                     $this->task('Stopping Docker service ', $this->docker->stopDockerService());
                 }

--- a/app/Commands/DisableCommand.php
+++ b/app/Commands/DisableCommand.php
@@ -63,7 +63,10 @@ class DisableCommand extends Command
 
     public function showDisableServiceMenu(): void
     {
-        $serviceContainerId = $this->menu('Services to disable', $this->disableableServices)->open();
+        $serviceContainerId = $this->menu('Services to disable', $this->disableableServices)
+            ->addLineBreak('', 1)
+            ->setPadding(2, 5)
+            ->open();
 
         if ($serviceContainerId) {
             $this->disableByContainerId($serviceContainerId);
@@ -84,7 +87,7 @@ class DisableCommand extends Command
             }
 
             if (count($this->docker->allContainers()) === 1) {
-                $option = $this->menu('No Containers are running. Turn off Docker for Mac?', [
+                $option = $this->menu('No containers are running. Turn off Docker for Mac?', [
                     'Yes',
                     'No',
                 ])->open();

--- a/app/Commands/EnableCommand.php
+++ b/app/Commands/EnableCommand.php
@@ -25,7 +25,10 @@ class EnableCommand extends Command
             return;
         }
 
-        $option = $this->menu('Services to enable', $this->enableableServices())->open();
+        $option = $this->menu('Services to enable', $this->enableableServices())
+            ->addLineBreak('', 1)
+            ->setPadding(2, 5)
+            ->open();
 
         if (! $option) {
             return;
@@ -37,7 +40,8 @@ class EnableCommand extends Command
     public function enableableServices(): array
     {
         return collect((new Services)->all())->mapWithKeys(function ($fqcn, $shortName) {
-            return [$shortName => Str::afterLast($fqcn, '\\')];
+            $fullName = Str::of($fqcn)->replace(['MsS', 'Sql'], ['MS S', 'SQL']);
+            return [$shortName => Str::afterLast($fullName, '\\')];
         })->toArray();
     }
 

--- a/app/Commands/EnableCommand.php
+++ b/app/Commands/EnableCommand.php
@@ -40,8 +40,7 @@ class EnableCommand extends Command
     public function enableableServices(): array
     {
         return collect((new Services)->all())->mapWithKeys(function ($fqcn, $shortName) {
-            $fullName = Str::of($fqcn)->replace(['MsS', 'Sql'], ['MS S', 'SQL']);
-            return [$shortName => Str::afterLast($fullName, '\\')];
+            return [$shortName => Str::afterLast($this->formatName($fqcn), '\\')];
         })->toArray();
     }
 
@@ -49,5 +48,12 @@ class EnableCommand extends Command
     {
         $fqcn = (new Services)->get($service);
         app($fqcn)->enable();
+    }
+
+    private function formatName(string $name): string
+    {
+        $search = ['MsSql', 'MySql', 'PostgreSql'];
+        $replace = ['MS SQL', 'MySQL', 'PostgreSQL'];
+        return Str::of($name)->replace($search, $replace);
     }
 }


### PR DESCRIPTION
## Changes:

- Official dependencies names displayed instead of their class names (No more visual confusion between MsSql & MySql)
- Line break to separate the exit menu item from the rest
- Padding around the menu to help the text breathe

## Improvements:

I think the UI would be awesome with greater vertical padding around the menu items text.
I haven't found a way to do so.
Any suggestion?

## Preview:
![image](https://user-images.githubusercontent.com/19224681/91547897-ddf2e900-e924-11ea-8a09-659fec65def4.png)
