### PR TITLE
Add DynamoDB service

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ But you can also easily enable ElasticSearch, PostgreSQL, MSSQL, Redis, and more
 - Memcached
 - MailHog
 - MariaDB
+- DynamoDB
 
 ## Requirements
 

--- a/app/Services/DynamoDB.php
+++ b/app/Services/DynamoDB.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Services;
+
+class DynamoDB extends BaseService
+{
+    protected $organization = 'cnadiminti';
+    protected $imageName = 'dynamodb-local';
+    protected $defaultPort = 8000;
+    protected $prompts = [
+        [
+            'shortname' => 'volume',
+            'prompt' => 'What is the Docker volume name?',
+            'default' => 'dynamodb_data',
+        ],
+    ];
+
+    protected $dockerRunTemplate = '-p "$port":8000 \
+        -v "$volume":/dynamodb_local_db \
+        "$organization"/"$image_name":"$tag"';
+}

--- a/app/Services/DynamoDB.php
+++ b/app/Services/DynamoDB.php
@@ -4,7 +4,7 @@ namespace App\Services;
 
 class DynamoDB extends BaseService
 {
-    protected $organization = 'cnadiminti';
+    protected $organization = 'amazon';
     protected $imageName = 'dynamodb-local';
     protected $defaultPort = 8000;
     protected $prompts = [
@@ -16,6 +16,8 @@ class DynamoDB extends BaseService
     ];
 
     protected $dockerRunTemplate = '-p "$port":8000 \
+        -u root \
         -v "$volume":/dynamodb_local_db \
-        "$organization"/"$image_name":"$tag"';
+        "$organization"/"$image_name":"$tag" \
+        -jar DynamoDBLocal.jar --sharedDb -dbPath /dynamodb_local_db';
 }


### PR DESCRIPTION
This PR had service for DynamoDB.
I used [cnadiminti/dynamodb-local](https://hub.docker.com/r/cnadiminti/dynamodb-local) docker image instead of official one from amazon [amazon/dynamodb-local](https://hub.docker.com/r/amazon/dynamodb-local) because the amazon image uses in memory db and is not configurable. In order to use a volume for the database with official image we should override the image command.