### PR TITLE
Fix Minio run command

### DIFF
--- a/app/Services/Minio.php
+++ b/app/Services/Minio.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 class Minio extends BaseService
 {
+    protected $organization = 'minio';
     protected $imageName = 'minio';
     protected $defaultPort = 9000;
     protected $prompts = [
@@ -15,12 +16,12 @@ class Minio extends BaseService
         [
             'shortname' => 'access_key',
             'prompt' => 'What will the access key for Minio be?',
-            'default' => 'minio',
+            'default' => 'minioadmin',
         ],
         [
             'shortname' => 'secret_key',
             'prompt' => 'What will the secret key for Minio be?',
-            'default' => 'minio',
+            'default' => 'minioadmin',
         ],
     ];
 
@@ -28,5 +29,5 @@ class Minio extends BaseService
         -e MINIO_ACCESS_KEY=$access_key
         -e MINIO_SECRET_KEY=$secret_key
         -v "$volume":/data \
-        "$organization"/"$image_name":"$tag"';
+        "$organization"/"$image_name":"$tag" server /data';
 }


### PR DESCRIPTION
This PR fixes several bugs with running Minio
1) The organization was missing causing the command to fail
2) The default keys were too short (Minio requires 8+ characters)
3) The command was missing `server /data` as outlined [here](https://hub.docker.com/r/minio/minio/)

These fixes should construct the proper command to run the docker image
`docker run -p 9000:9000 -e MINIO_ACCESS_KEY=minioadmin -e MINIO_SECRET_KEY=minioadmin -v minio_data:/data minio/minio:latest server /data`