### PR TITLE
Fixing minio run template bug '\'

### DIFF
--- a/app/Services/Minio.php
+++ b/app/Services/Minio.php
@@ -26,8 +26,8 @@ class Minio extends BaseService
     ];
 
     protected $dockerRunTemplate = '-p "$port":9000 \
-        -e MINIO_ACCESS_KEY=$access_key
-        -e MINIO_SECRET_KEY=$secret_key
+        -e MINIO_ACCESS_KEY=$access_key \
+        -e MINIO_SECRET_KEY=$secret_key \
         -v "$volume":/data \
         "$organization"/"$image_name":"$tag" server /data';
 }


### PR DESCRIPTION
Just added the \ to fix the minio run command.