### PR TITLE
Add JSON output option to container list

### DIFF
--- a/app/Commands/ListCommand.php
+++ b/app/Commands/ListCommand.php
@@ -4,13 +4,14 @@ namespace App\Commands;
 
 use App\InitializesCommands;
 use App\Shell\Docker;
+use Illuminate\Support\Str;
 use LaravelZero\Framework\Commands\Command;
 
 class ListCommand extends Command
 {
     use InitializesCommands;
 
-    protected $signature = 'list';
+    protected $signature = 'list {--json}';
     protected $description = 'List all services enabled by Takeout.';
 
     public function handle(): void
@@ -18,6 +19,20 @@ class ListCommand extends Command
         $this->initializeCommand();
 
         $containers = app(Docker::class)->takeoutContainers();
+
+        if ($this->option('json')) {
+            $keys = collect(array_shift($containers))->map(function ($key) {
+                return Str::slug($key, '_');
+            })->toArray();
+
+            $containers = collect($containers)->map(function ($container) use ($keys) {
+                return array_combine($keys, $container);
+            });
+
+            $this->line(json_encode($containers));
+
+            return;
+        }
 
         $this->line("\n");
         $this->table(array_shift($containers), $containers);


### PR DESCRIPTION
This PR adds a JSON output option to the `takeout list` command.

If one would want to build a Desktop application for Takeout, this could be pretty handy 👀